### PR TITLE
Feedback on flicker implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /__pycache__/*
 /data/*
 *.psyexp
+.venv

--- a/flicker_test.py
+++ b/flicker_test.py
@@ -68,11 +68,11 @@ if rate is None:
     rate = 60  # couldn't get a reliable measure so guess
 print(f"Frame rate: {rate:0.5f} Hz")
 expInfo["frameRate"] = rate
-win.hideMessage()
+win.hideMessage()  # looks like this does nothing
 
 frameTolerance = 0.001  # how close to onset before 'same' frame
 # get frame duration from frame rate in expInfo
-if "frameRate" in expInfo and expInfo["frameRate"] is not None:
+if expInfo.get("frameRate", None) is not None:
     frameDur = 1.0 / expInfo["frameRate"]
 else:
     raise ValueError("Frame rate not measured correctly. Check hardware.")
@@ -142,13 +142,21 @@ for key, val in timing_info.items():
 continueRoutine = True
 routineForceEnd = False
 actual_framerate = {0: [], 1: []}
-globalClock = core.Clock()
-ioServer.syncClock(globalClock)
-routineTimer = core.Clock()
+globalClock = core.Clock()  # duplicate from line 110-112
+ioServer.syncClock(globalClock)  # duplicate from line 110-112
+routineTimer = core.Clock()  # duplicate from line 110-112
 win.flip()
 actual_t = {0: [], 1: []}
 while continueRoutine and routineTimer.getTime() < (WORDSTART + WORDLEN):
     # get current time
+    # Personaly, I would use psychtoolbox to manage time. The method win.getFutureFlipTime() accepts
+    # clock="ptb" as argument, which then returns the time as given by psychtoolbox. I would compare
+    # this returned time with ptb.GetSecs(). 
+    # The rational is that many people have told me that the timings in psychtoolbox are more 
+    # reliable/precise, that psychopy encourages people to use psychtoolbox for audio outputs heavily
+    # (see: https://psychopy.org/api/sound/playback.html#ptb-audio-latency), that psychopy's clock
+    # implementation uses psychtoolbox if available 
+    # (see: https://www.psychopy.org/_modules/psychopy/clock.html).
     t = routineTimer.getTime()
     tThisFlip = win.getFutureFlipTime(clock=routineTimer)
     tThisFlipGlobal = win.getFutureFlipTime(clock=None)

--- a/flicker_test_mathieu.py
+++ b/flicker_test_mathieu.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+import psychtoolbox as ptb
+from psychopy.visual import ShapeStim, TextStim, Window
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+# constants
+WINDOW_CONFIG: dict[str, int | bool | list[int] | tuple[int, ...] | str] = {
+    "screen": 0,  # 0 is the primary monitor
+    "fullscr": True,
+    "winType": "pyglet",
+    "allowStencil": False,
+    "monitor": "testMonitor",
+    "color": [0, 0, 0],
+    "colorSpace": "rgb",
+    "units": "deg",
+    "checkTiming": False,
+}
+TEXT_CONFIG: dict[str, str | float | None] = {
+    "font": "Arial",
+    "height": 2.0,
+    "wrapWidth": None,
+    "ori": 0.0,
+    "color": "white",
+    "colorSpace": "rgb",
+    "opacity": None,
+    "languageStyle": "LTR",
+    "depth": 0.0,
+}
+WORD_SEP: int = 4  # word separation in degrees
+FLICKER_RATES: NDArray[np.float64] = np.array([20.0, 2.0])  # Hz
+
+
+# initialize components
+class Components:
+    def __init__(self):
+        self.win = Window(**WINDOW_CONFIG)
+        self.framerate = self.win.getActualFrameRate()
+        self.framerate = 60 if self.framerate is None else self.framerate
+        self.word0 = TextStim(
+            win=self.win,
+            text="Red",
+            pos=(-(WORD_SEP / 2), 0),
+            **TEXT_CONFIG,
+        )
+        self.word1 = TextStim(
+            win=self.win,
+            text="Boat",
+            pos=(WORD_SEP / 2, 0),
+            **TEXT_CONFIG,
+        )
+        self.fixation_dot = ShapeStim(
+            win=self.win,
+            size=(0.05, 0.05),
+            vertices="circle",
+            anchor="center",
+            colorSpace="rgb",
+            lineColor="white",
+            fillColor="white",
+            interpolate=True,
+        )
+        self.fixation_dot.setAutoDraw(True)
+        self.word0.setAutoDraw(True)
+        self.word1.setAutoDraw(True)
+        self.last_flip = None
+        self.win.callOnFlip(self._get_PTB_flip_time)
+
+    def _get_PTB_flip_time(self):
+        self.last_flip = ptb.GetSecs()
+
+
+components = Components()
+win = components.win
+# determine target timings
+win.flip()
+targets = dict(
+    word0=(1 / FLICKER_RATES[0]) + components.last_flip,
+    word1=1 / FLICKER_RATES[1] + components.last_flip,
+)
+
+timings = dict(word0=[], word1=[])
+start = ptb.GetSecs()  # timer condition to end the loop
+while ptb.GetSecs() <= start + 10:
+    next_flip = win.getFutureFlipTime(clock="ptb")
+    for key, value in targets.items():
+        component = getattr(components, key)
+        if next_flip >= value:
+            component.setAutoDraw(not component.getAutoDraw())
+            targets[key] += 1 / FLICKER_RATES[int(key[-1])]
+            timings[key].append(components.last_flip)
+    win.flip()
+    win.callOnFlip(components._get_PTB_flip_time)  # reset on every-flip
+
+df_timings = {key: pd.Series(value).diff().describe() for key, value in timings.items()}
+print(pd.concat(df_timings, axis=1).rename(columns={0: "word0", 1: "word1"}))


### PR DESCRIPTION
Hello!

Please find in the PR comments and feedback on the implementation. My main points are:

- I would used `psychtoolbox` and it's function `GetSecs()` to manage time. My comment in the code-base give some context, but it's a bit difficult to know when psychopy is using `timeit.default_timer` or `psychtoolbox.GetSecs`, so instead of trying to juggle with the different clock base I prefer to directly force/ensure I use PTB. After looking through the codebase of psychopy, it does seem that it will default to PTB anyway if it's available; but some functions will return the true PTB time while other will return it with an offset.
- The `ioServer` and `DeviceManager` are completely optional. The `Window` object and `Keyboard` object (https://psychopy.org/api/hardware/keyboard.html) can be managed in the main process/thread without overhead. Personally, I never use `ioServer` and `DeviceManager` but I don't think they will hurt you anyway, they just make the code more complex without any good reason to do so.
- The `ioServer.syncClock` calls seems pointless, I'm not sure why you would need to sync it for (keyboard is only used to quit the experiment + not sure what it synchronizes).

I also drafted a minimal implementation, getting close timings to yours with a simpler main loop. Maybe it can give you some ideas/tips to further improve your loop (which seems slightly more stable/performant anyway!)

Timings on my computer:

```
# your test script

            word0      word1
count  138.000000  12.000000
mean     0.050041   0.500406
std      0.000105   0.000157
min      0.049603   0.500014
25%      0.050008   0.500326
50%      0.050041   0.500447
75%      0.050091   0.500492
max      0.050347   0.500586
```

```
# my test script

            word0      word1
count  199.000000  19.000000
mean     0.050041   0.500419
std      0.000133   0.000276
min      0.049466   0.499817
25%      0.049959   0.500419
50%      0.050042   0.500441
75%      0.050126   0.500465
max      0.050580   0.501019
```
